### PR TITLE
[minor] fix Incorrect class name used in Workflow Core documentation 

### DIFF
--- a/docs/userguide/concepts.md
+++ b/docs/userguide/concepts.md
@@ -76,7 +76,7 @@ When that is called, `EmailInboxWorkflow` enqueues an Action function that emits
 ![Workflow schematic showing EmailBrowserWorkflow rendering by delegating to two children, InboxWorkflow and MessageWorkflow, and assembling their renderings into its own.](../images/split_screen_update.svg)
 
 Whenever such a [Workflow Action cascade](../../glossary#action-cascade) fires, the root Workflow is asked for a new Rendering.
-Just as before, `EmailInboxWorkflow` delegates to its two children for their Renderings, this time providing the new value of `selection` as the updated Props for `MessageWorkflow`.
+Just as before, `EmailBrowserWorkflow` delegates to its two children for their Renderings, this time providing the new value of `selection` as the updated Props for `MessageWorkflow`.
 
 <!-- ## Workers for I/O and other side effects
 


### PR DESCRIPTION
Within the `Workflow Core -> Composing Workflows` [documentation](https://square.github.io/workflow/userguide/concepts/#composing-workflows), a minor error can be noticed in the last paragraph. It appears that an incorrect class name has been used to refer to the parent workflow, which is contrary to the documentation context and understanding. Based on my understanding, the parent workflow should be correctly identified as `EmailBrowserWorkflow`, rather than `EmailInboxWorkflow`. 

The paragraph I am referring to is:
> Whenever such a [Workflow Action cascade](https://square.github.io/workflow/glossary#action-cascade) fires, the root Workflow is asked for a new Rendering. Just as before, EmailInboxWorkflow delegates to its two children for their Renderings, this time providing the new value of selection as the updated Props for MessageWorkflow.